### PR TITLE
Units division now honors order of operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>4.3.2</version>
+    <version>4.3.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>4.3.4</version>
+    <version>4.3.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/Measure.java
+++ b/src/main/java/javax/measure/Measure.java
@@ -235,8 +235,6 @@ public abstract class Measure<V, Q extends Quantity> implements Measurable<Q>,
      * @return  a negative integer, zero, or a positive integer as this measure
      *          is less than, equal to, or greater than the specified measurable
      *          quantity.
-      * @return <code>Double.compare(this.doubleValue(getUnit()), 
-      *         that.doubleValue(getUnit()))</code>
      */
     public int compareTo(Measurable<Q> that) {
         return java.lang.Double.compare(doubleValue(getUnit()), that

--- a/src/main/java/javax/measure/unit/SubUnit.java
+++ b/src/main/java/javax/measure/unit/SubUnit.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
+
+/*
+ * (C) Copyright Taligent, Inc. 1996, 1997 - All Rights Reserved
+ * (C) Copyright IBM Corp. 1996 - 1998 - All Rights Reserved
+ *
+ *   The original version of this source code and documentation is copyrighted
+ * and owned by Taligent, Inc., a wholly-owned subsidiary of IBM. These
+ * materials are provided under terms of a License Agreement between Taligent
+ * and Sun. This technology is protected by multiple US and International
+ * patents. This notice and attribution to Taligent may not be removed.
+ *   Taligent is a registered trademark of Taligent, Inc.
+ *
+ */
+
+package javax.measure.unit;
+
+
+import java.text.ParsePosition;
+
+class SubUnit {
+    private String subUnit = "";
+    private int parsePositionIncrement = 0;
+
+    /**
+     * Extract the first subunit from a unit product string. The subunit is the first part of the unit string that
+     * should be parsed. The subunit may also be a unit product.
+     * For example: <br>
+     * Input: kg/s               SubUnit: kg <br>
+     * Input: (m/s)/kg           SubUnit: m/s <br>
+     * Input: ((m/s)/(kg/h))*N   SubUnit: (m/s)/(kg/h) <br>
+     *
+     * Parse position increment is also provided which is the count of the characters used up by the subunit.
+     * SubUnit is used in conjunction with {@link UnitFormat#parseProductUnit(CharSequence, ParsePosition)} which
+     * tracks the parse position.
+     *
+     * @param unit
+     *         The unit string from which to extract a subunit.
+     */
+    SubUnit(CharSequence unit) {
+        if (unit.charAt(0) == '(') {
+            // When the input string starts with a '(', find the outside parenthesis pair and return everything
+            // inside. The outside parenthesis pair is not included in the returned subunit.
+            StringBuilder subUnitBuilder = new StringBuilder("");
+            int leftParenCount = 1;
+            int rightParenCount = 0;
+
+            // Strip the leading '(' and process the rest of the characters.
+            for (char c : unit.subSequence(1, unit.length()).toString().toCharArray()) {
+                if (c == '(') {
+                    leftParenCount++;
+                } else if (c == ')') {
+                    rightParenCount++;
+                    if (rightParenCount == leftParenCount) {
+                        // Everything inside the outside parenthesis pair has been found. We are done.
+                        break;
+                    }
+                }
+
+                subUnitBuilder.append(c);
+            }
+            this.subUnit = subUnitBuilder.toString();
+            this.parsePositionIncrement = this.subUnit.length() + 2; // +2 for the outside paren pair
+        } else {
+            // When the input string doesn't start with a '(', extract all the characters up until a multiply, divide
+            // or closing ')'. (There may be an unmatched closing parenthesis because the leading parenthesis may
+            // have already been stripped by UnitFormat#parseProductUnit.)
+            this.subUnit = unit.toString().split("[\\/\\)*·]")[0];
+            this.parsePositionIncrement = this.subUnit.length();
+        }
+    }
+
+    /**
+     * The count of the characters used up by the subunit. SubUnit is used in conjunction with {@link
+     * UnitFormat#parseProductUnit(CharSequence, ParsePosition)} which tracks the
+     * parse position.
+     *
+     * @return The count of the characters used up by the subunit.
+     */
+    int getParsePositionIncrement() { return parsePositionIncrement; }
+
+    /**
+     * The first subunit from a unit product string. The subunit is the first part of the unit string that should
+     * be parsed. The subunit may also be a unit product.
+     *
+     * @return The subunit.
+     */
+    String getSubUnit() { return subUnit; }
+}

--- a/src/main/java/javax/measure/unit/SubUnit.java
+++ b/src/main/java/javax/measure/unit/SubUnit.java
@@ -1,43 +1,4 @@
-/*
- * Copyright (c) 1996, 2013, Oracle and/or its affiliates. All rights reserved.
- * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- */
-
-/*
- * (C) Copyright Taligent, Inc. 1996, 1997 - All Rights Reserved
- * (C) Copyright IBM Corp. 1996 - 1998 - All Rights Reserved
- *
- *   The original version of this source code and documentation is copyrighted
- * and owned by Taligent, Inc., a wholly-owned subsidiary of IBM. These
- * materials are provided under terms of a License Agreement between Taligent
- * and Sun. This technology is protected by multiple US and International
- * patents. This notice and attribution to Taligent may not be removed.
- *   Taligent is a registered trademark of Taligent, Inc.
- *
- */
-
 package javax.measure.unit;
-
 
 import java.text.ParsePosition;
 

--- a/src/main/java/javax/measure/unit/UnitFormat.java
+++ b/src/main/java/javax/measure/unit/UnitFormat.java
@@ -16,6 +16,7 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Stack;
 //@RETROWEAVER import javolution.text.Appendable;
 import javax.measure.converter.AddConverter;
 import javax.measure.converter.MultiplyConverter;
@@ -384,6 +385,7 @@ public abstract class UnitFormat extends Format {
         @Override
         public Unit<? extends Quantity> parseProductUnit(CharSequence csq, ParsePosition pos) 
                 throws ParseException {
+            checkForBalancedParentheses(csq);
             Unit result = Unit.ONE;
             int token = nextToken(csq, pos);
             switch (token) {
@@ -532,8 +534,31 @@ public abstract class UnitFormat extends Format {
                         + " at index " + index + ")", index);
             }
         }
-        
-        private Exponent readExponent (CharSequence csq, ParsePosition pos) {
+
+        private void checkForBalancedParentheses(CharSequence csq) throws ParseException {
+            Stack<Character> stack = new Stack<Character>();
+            int i = 0;
+            for (i = 0; i < csq.length(); i++) {
+                char c = csq.charAt(i);
+                if (c == '(') {
+                    stack.push(c);
+                } else if (c == ')') {
+                    if (stack.isEmpty()) {
+                        throw new ParseException("Unmatched parenthesis in " + csq
+                                + " at index " + i + ")", i);
+                    } else {
+                        stack.pop();
+                    }
+                }
+            }
+
+            if (!stack.isEmpty()) {
+                throw new ParseException("Unmatched parenthesis in " + csq
+                        + " at index " + i + ")", i);
+            }
+        }
+
+        private Exponent readExponent(CharSequence csq, ParsePosition pos) {
             char c = csq.charAt(pos.getIndex());
             if (c == '^') {
                 pos.setIndex(pos.getIndex()+1);

--- a/src/main/java/javax/measure/unit/UnitFormat.java
+++ b/src/main/java/javax/measure/unit/UnitFormat.java
@@ -441,7 +441,9 @@ public abstract class UnitFormat extends Format {
                             result = result.divide(d);
                         }
                     } else {
-                        result = result.divide(parseProductUnit(csq, pos));
+                        SubUnit subUnit = new SubUnit(csq.subSequence(pos.getIndex(), csq.length()));
+                        pos.setIndex(pos.getIndex() + subUnit.getParsePositionIncrement());
+                        result = result.divide(parseProductUnit(subUnit.getSubUnit(), new ParsePosition(0)));
                     }
                     break;
                 case PLUS:

--- a/src/main/java/org/jscience/physics/amount/Constants.java
+++ b/src/main/java/org/jscience/physics/amount/Constants.java
@@ -116,8 +116,7 @@ public final class Constants {
 
     /**
      * Holds the Planck constant.
-     * @see <a href="http://en.wikipedia.org/wiki/Plank%27s_constant">
-     *      Wikipedia: Plank's constant</a>
+     * @see <a href="http://en.wikipedia.org/wiki/Planck_constant">Wikipedia: Planck constant</a>
      */
     public final static Amount<?> ℎ = Amount.valueOf(
         6.6260693E-34, 0.0000011E-34, SI.JOULE.times(SI.SECOND));
@@ -176,8 +175,8 @@ public final class Constants {
 
     /**
      * Holds the Avogadro constant.
-     * @see <a href="http://en.wikipedia.org/wiki/Avogadro%27s_number">
-     *      Wikipedia: Avogadro's number</a>
+     * @see <a href="https://en.wikipedia.org/wiki/Avogadro_constant">
+     *      Wikipedia: Avogadro constant</a>
      */
     public final static Amount<?> N = Amount.valueOf(
         6.0221415E23, 0.0000010E23, Unit.ONE.divide(SI.MOLE));

--- a/src/test/java/javax/measure/unit/SubUnitTest.java
+++ b/src/test/java/javax/measure/unit/SubUnitTest.java
@@ -1,0 +1,23 @@
+package javax.measure.unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+
+public class SubUnitTest {
+    @Test
+    public void testSubUnit() {
+        SubUnit subUnit = new SubUnit("kg/s");
+        assertThat(subUnit.getSubUnit()).isEqualTo("kg");
+        assertThat(subUnit.getParsePositionIncrement()).isEqualTo(2);
+
+        subUnit = new SubUnit("(m/s)/kg ");
+        assertThat(subUnit.getSubUnit()).isEqualTo("m/s");
+        assertThat(subUnit.getParsePositionIncrement()).isEqualTo(5);
+
+        subUnit = new SubUnit("((m/s)/(kg/h))*N");
+        assertThat(subUnit.getSubUnit()).isEqualTo("(m/s)/(kg/h)");
+        assertThat(subUnit.getParsePositionIncrement()).isEqualTo(14);
+    }
+}

--- a/src/test/java/javax/measure/unit/UnitTest.java
+++ b/src/test/java/javax/measure/unit/UnitTest.java
@@ -1,6 +1,7 @@
 package javax.measure.unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -12,49 +13,30 @@ import org.junit.Test;
 
 public class UnitTest {
     @Test
-    public void test() {
+    public void testBasic() {
         // Order of operations appears to be messed up when it comes to division
         assertThat(Unit.valueOf("g/m/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
-    }
-
-    @Test
-    public void test2() {
-        // Order of operations appears to be messed up when it comes to division
         assertThat(Unit.valueOf("(g/m)/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
     }
 
     @Test
-    public void test3() {
-        // Order of operations appears to be messed up when it comes to division
-        assertThat(Unit.valueOf("m/(g/s)")).isEqualTo(SI.METER.times(SI.SECOND).divide(SI.GRAM));
-    }
+    public void testUnmatchedParentheses() {
+        assertThatThrownBy(() -> Unit.valueOf("N/(g/s")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unmatched parenthesis").hasMessageContaining("index 6");
 
-    @Test
-    public void test4() {
-        // Order of operations appears to be messed up when it comes to division
-        assertThat(Unit.valueOf("m/g*s")).isEqualTo(SI.METER.times(SI.SECOND).divide(SI.GRAM));
-    }
+        assertThatThrownBy(() -> Unit.valueOf("N/g)/s")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unmatched parenthesis").hasMessageContaining("index 3");
 
+        assertThatThrownBy(() -> Unit.valueOf("((N/g)/s")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unmatched parenthesis").hasMessageContaining("index 8");
 
-    @Test
-    public void test5() {
-        // Order of operations appears to be messed up when it comes to division
-        assertThat(Unit.valueOf("(m/g)/s")).isEqualTo(SI.METER.divide(SI.GRAM).divide(SI.SECOND));
-    }
-
-    @Test
-    public void test6() {
-        // Order of operations appears to be messed up when it comes to division
-        assertThat(Unit.valueOf("N/(g/(m/s))")).isEqualTo(SI.NEWTON.times(SI.METER).divide(SI.GRAM).divide(SI.SECOND));
-    }
-
-    @Test
-    public void test7() {
-        // Order of operations appears to be messed up when it comes to division
-        assertThat(Unit.valueOf("N/(g)/s")).isEqualTo(SI.NEWTON.divide(SI.GRAM).divide(SI.SECOND));
+        assertThatThrownBy(() -> Unit.valueOf("(N/g))/s")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unmatched parenthesis").hasMessageContaining("index 5");
     }
 
 
+    // The jscience library 4.3.1 did not follow the order of operations when division was involved.  These tests
+    // all failed before the fix was made.
     @Test
     public void testParseUnitsWithDivisions() throws Exception {
 

--- a/src/test/java/javax/measure/unit/UnitTest.java
+++ b/src/test/java/javax/measure/unit/UnitTest.java
@@ -48,6 +48,27 @@ public class UnitTest {
             // Test it again but replace * with ·.  Example: m/kg*h -> m/kg·h
             parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("*", "·")).toString();
             softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue());
+
+            // Test it again but replace N with N^2.  Example: N/kg*h -> N^2/kg*h
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("N", "N^2")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue().replace("N", "N²"));
+
+            // Test it again but replace kg with kg^2.  Example: m/kg*h -> m/kg^2*h
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("kg", "kg^2")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue().replace("kg", "kg²"));
+
+            // Test it again but replace kg with kg².  Example: m/kg*h -> m/kg²*h
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("kg", "kg²")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue().replace("kg", "kg²"));
+
+            // Test it again but replace h with h^2.  Example: m/kg*h -> m/kg*h^2
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("h", "h^2")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue().replace("h", "h²"));
+
+            // Test it again but replace m with m^2.  Example: m/kg*h -> m^2/kg*h
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("m", "m^2")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue().replace("m", "m²"));
+
         }
 
         softly.assertAll();

--- a/src/test/java/javax/measure/unit/UnitTest.java
+++ b/src/test/java/javax/measure/unit/UnitTest.java
@@ -1,11 +1,153 @@
 package javax.measure.unit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
+
 
 public class UnitTest {
     @Test
     public void test() {
         // Order of operations appears to be messed up when it comes to division
-        //assertThat(Unit.valueOf("m/s/s")).isEqualTo(SI.METER.divide(SI.SECOND).divide(SI.SECOND));
+        assertThat(Unit.valueOf("g/m/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
+    }
+
+    @Test
+    public void test2() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("(g/m)/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
+    }
+
+    @Test
+    public void test3() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("m/(g/s)")).isEqualTo(SI.METER.times(SI.SECOND).divide(SI.GRAM));
+    }
+
+    @Test
+    public void test4() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("m/g*s")).isEqualTo(SI.METER.times(SI.SECOND).divide(SI.GRAM));
+    }
+
+
+    @Test
+    public void test5() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("(m/g)/s")).isEqualTo(SI.METER.divide(SI.GRAM).divide(SI.SECOND));
+    }
+
+    @Test
+    public void test6() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("N/(g/(m/s))")).isEqualTo(SI.NEWTON.times(SI.METER).divide(SI.GRAM).divide(SI.SECOND));
+    }
+
+    @Test
+    public void test7() {
+        // Order of operations appears to be messed up when it comes to division
+        assertThat(Unit.valueOf("N/(g)/s")).isEqualTo(SI.NEWTON.divide(SI.GRAM).divide(SI.SECOND));
+    }
+
+
+    @Test
+    public void testParseUnitsWithDivisions() throws Exception {
+
+        SoftAssertions softly = new SoftAssertions();
+
+        for (Map.Entry<String, String> divisionUnit : DIVISION_UNITS.entrySet()) {
+            String parsedUnit = Unit.valueOf(divisionUnit.getKey()).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue());
+
+            // Test it again but replace * with ·.  Example: m/kg*h -> m/kg·h
+            parsedUnit = Unit.valueOf(divisionUnit.getKey().replace("*", "·")).toString();
+            softly.assertThat(parsedUnit).isEqualTo(divisionUnit.getValue());
+        }
+
+        softly.assertAll();
+    }
+
+    private static final Map<String, String> DIVISION_UNITS;
+
+    static {
+        Map<String, String> map = new LinkedHashMap<String, String>();
+
+        // 1 Divide
+        map.put("N/kg", "N/kg");
+
+        // 2 Divides
+        map.put("N/kg/h", "N/(kg·h)");
+        map.put("(N/kg)/h", "N/(kg·h)");
+        map.put("N/(kg/h)", "N·h/kg");
+        map.put("N/(kg)/h", "N/(kg·h)");
+
+        // 1 Divide+ 1 Multiply
+        map.put("N*kg/h", "N·kg/h");
+        map.put("(N*kg)/h", "N·kg/h");
+        map.put("N*(kg/h)", "N·kg/h");
+        map.put("N*(kg)/h", "N·kg/h");
+
+        map.put("N/kg*h", "N·h/kg");
+        map.put("(N/kg)*h", "N·h/kg");
+        map.put("N/(kg*h)", "N/(kg·h)");
+        map.put("N/(kg)*h", "N·h/kg");
+
+        // 3 Divides
+        map.put("N/kg/m/h", "N/(kg·m·h)");
+        map.put("((N/kg)/m)/h", "N/(kg·m·h)");
+        map.put("(N/kg)/(m/h)", "N·h/(kg·m)");
+        map.put("N/(kg/(m/h))", "N·m/(kg·h)");
+
+        map.put("(N/kg)/m/h", "N/(kg·m·h)");
+        map.put("N/(kg/m)/h", "N·m/(kg·h)");
+        map.put("N/kg/(m/h)", "N·h/(kg·m)");
+
+        // 2 Divides + 1 Multiply
+        map.put("N*kg/m/h", "N·kg/(m·h)");
+        map.put("N/kg*m/h", "N·m/(kg·h)");
+        map.put("N/kg/m*h", "N·h/(kg·m)");
+
+        map.put("(N*kg)/m/h", "N·kg/(m·h)");
+        map.put("(N/kg)*m/h", "N·m/(kg·h)");
+        map.put("(N/kg)/m*h", "N·h/(kg·m)");
+
+        map.put("N*(kg/m)/h", "N·kg/(m·h)");
+        map.put("N/(kg*m)/h", "N/(kg·m·h)");
+        map.put("N/(kg/m)*h", "N·m·h/kg");
+
+        map.put("N*kg/(m/h)", "N·kg·h/m");
+        map.put("N/kg*(m/h)", "N·m/(kg·h)");
+        map.put("N/kg/(m*h)", "N/(kg·m·h)");
+
+        // 1 Divide + 2 Multiplies
+        map.put("N/kg*m*h", "N·m·h/kg");
+        map.put("N*kg/m*h", "N·kg·h/m");
+        map.put("N*kg*m/h", "N·kg·m/h");
+
+        map.put("(N/kg)*m*h", "N·m·h/kg");
+        map.put("(N*kg)/m*h", "N·kg·h/m");
+        map.put("(N*kg)*m/h", "N·kg·m/h");
+
+        map.put("N/(kg*m)*h", "N·h/(kg·m)");
+        map.put("N*(kg/m)*h", "N·kg·h/m");
+        map.put("N*(kg*m)/h", "N·kg·m/h");
+
+        map.put("N/kg*(m*h)", "N·m·h/kg");
+        map.put("N*kg/(m*h)", "N·kg/(m·h)");
+        map.put("N*kg*(m/h)", "N·kg·m/h");
+
+        // 3 Divides Total, 2 within ()
+        map.put("(N/kg/m)/h", "N/(kg·m·h)");
+        map.put("N/(kg/m/h)", "N·m·h/kg");
+
+        // 4 Divides
+        map.put("N/kg/m/h/K", "N/(kg·m·h·K)");
+
+        DIVISION_UNITS = Collections.unmodifiableMap(map);
     }
 }

--- a/src/test/java/javax/measure/unit/UnitTest.java
+++ b/src/test/java/javax/measure/unit/UnitTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 public class UnitTest {
     @Test
     public void testBasic() {
-        // Order of operations appears to be messed up when it comes to division
         assertThat(Unit.valueOf("g/m/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
         assertThat(Unit.valueOf("(g/m)/s")).isEqualTo(SI.GRAM.divide(SI.METER).divide(SI.SECOND));
     }


### PR DESCRIPTION
Before: `a/b/c = a*c/b`
After: `a/b/c = a/(b*c)`

The problem was that division was using recursion which means that division was starting at the right and moving to the left.

Primary: Dustin