### PR TITLE
CRAB-24112: Add mbar support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.2-SNAPSHOT</version>
+    <version>5.4.3-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.0.0</version>
+    <version>5.4.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.1-SNAPSHOT</version>
+    <version>5.4.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.3-SNAPSHOT</version>
+    <version>5.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/unit/NonSI.java
+++ b/src/main/java/javax/measure/unit/NonSI.java
@@ -581,10 +581,16 @@ public final class NonSI extends SystemOfUnits {
     public static final Unit<Pressure> ATMOSPHERE = nonSI(PASCAL.times(101325));
 
     /**
+     * An invented unit of pressure equal to <code>1 Pa</code>
+     * This exists to stop the collision of hPa and mbar.
+     * Deka-Micro = 10 * 10^-6 = 10^-5.
+     */
+    private static final Unit<Pressure> DEKAMICROBAR = new AlternateUnit<>("daµbar", NEWTON.divide(METRE.pow(2)));
+
+    /**
      * A unit of pressure equal to <code>100 kPa</code>
      * (standard name <code>bar</code>).
      */
-    public static final Unit<Pressure> DEKAMICROBAR = new AlternateUnit<>("dubar", NEWTON.divide(METRE.pow(2)));
     public static final Unit<Pressure> BAR = nonSI(DEKAMICROBAR.times(100000));
 
     /**

--- a/src/main/java/javax/measure/unit/NonSI.java
+++ b/src/main/java/javax/measure/unit/NonSI.java
@@ -584,7 +584,7 @@ public final class NonSI extends SystemOfUnits {
      * A unit of pressure equal to <code>100 kPa</code>
      * (standard name <code>bar</code>).
      */
-    public static final Unit<Pressure> DEKAMICROBAR = nonSI(new AlternateUnit<>("dubar", NEWTON.divide(METRE.pow(2))));
+    public static final Unit<Pressure> DEKAMICROBAR = new AlternateUnit<>("dubar", NEWTON.divide(METRE.pow(2)));
     public static final Unit<Pressure> BAR = nonSI(DEKAMICROBAR.times(100000));
 
     /**

--- a/src/main/java/javax/measure/unit/NonSI.java
+++ b/src/main/java/javax/measure/unit/NonSI.java
@@ -584,7 +584,8 @@ public final class NonSI extends SystemOfUnits {
      * A unit of pressure equal to <code>100 kPa</code>
      * (standard name <code>bar</code>).
      */
-    public static final Unit<Pressure> BAR = nonSI(PASCAL.times(100000));
+    public static final Unit<Pressure> DEKAMICROBAR = nonSI(new AlternateUnit<>("dubar", NEWTON.divide(METRE.pow(2))));
+    public static final Unit<Pressure> BAR = nonSI(DEKAMICROBAR.times(100000));
 
     /**
      * A unit of pressure equal to the pressure exerted at the Earth's

--- a/src/test/java/javax/measure/unit/UnitTest.java
+++ b/src/test/java/javax/measure/unit/UnitTest.java
@@ -74,6 +74,15 @@ public class UnitTest {
         softly.assertAll();
     }
 
+    @Test
+    public void testPressureChanges() {
+        assertThat(NonSI.BAR.getConverterTo(SI.PASCAL).convert(1.0)).isEqualTo(100_000.0);
+        assertThat(SI.PASCAL.getConverterTo(NonSI.BAR).convert(100_000.0)).isEqualTo(1.0);
+        assertThat(NonSI.BAR.toString()).isEqualTo("bar");
+        assertThat(Unit.valueOf("bar")).isEqualTo(NonSI.BAR);
+        assertThat(Unit.valueOf("daµbar")).as("Regrettable that we need to expose this odd unit").isNotNull();
+    }
+
     private static final Map<String, String> DIVISION_UNITS;
 
     static {


### PR DESCRIPTION
Adds a new fake unit (deka-micro bars, representing 1/100,000th of a bar, aka 1 Pa, or 1 N/m^2). Then derive bar and mbar from this new unit. This allows for separate representations of mbar and hPa.