### PR TITLE
CRAB-26905: Improve Unit Converter Equals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ A stripped down fork of JScience's unit library (version 4.3.1) with various bug
 * 5.0.0: Added new dimensions to previously dimensionless concepts (radian, ppm, dB, and a few others).
     * Technically not a major version per semver, but the last one should have been.
 * 5.1.0: Reworked bar to be an AlternateUnit and not a TransformedUnit to avoid mbar/hPa collisions.
+* 5.2.1: Created alternate names for some units (in the future, these can be done within CRAB).
+* 5.2.2: Improved efficiency of UnitConverter.Equals in some cases.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.2-SNAPSHOT</version>
+    <version>5.2.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.4-SNAPSHOT</version>
+    <version>5.2.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.1</version>
+    <version>5.2.4-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.2</version>
+    <version>5.2.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/converter/AddConverter.java
+++ b/src/main/java/javax/measure/converter/AddConverter.java
@@ -71,6 +71,17 @@ public final class AddConverter extends UnitConverter {
         }
     }
 
+    @Override
+    public boolean equals(Object cvtr) {
+        if (this == cvtr) {
+            return true;
+        }
+        if (cvtr instanceof AddConverter) {
+            return this._offset == ((AddConverter) cvtr).getOffset();
+        }
+        return super.equals(cvtr);
+    }
+
     private static UnitConverter valueOf(double offset) {
         float asFloat = (float) offset;
         return asFloat == 0.0f ? UnitConverter.IDENTITY : new AddConverter(offset);

--- a/src/main/java/javax/measure/converter/MultiplyConverter.java
+++ b/src/main/java/javax/measure/converter/MultiplyConverter.java
@@ -82,5 +82,20 @@ public final class MultiplyConverter extends UnitConverter {
                 : new MultiplyConverter(factor);
     }
 
+    @Override
+    public boolean equals(Object cvtr) {
+        if (this == cvtr) {
+            return true;
+        }
+        if (cvtr instanceof MultiplyConverter) {
+            return this._factor == ((MultiplyConverter) cvtr).getFactor();
+        }
+        if (cvtr instanceof RationalConverter) {
+            RationalConverter that = (RationalConverter) cvtr;
+            return this._factor == ((double) that.getDividend()) / that.getDivisor();
+        }
+        return super.equals(cvtr);
+    }
+
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/javax/measure/converter/RationalConverter.java
+++ b/src/main/java/javax/measure/converter/RationalConverter.java
@@ -2,7 +2,7 @@
  * JScience - Java(TM) Tools and Libraries for the Advancement of Sciences.
  * Copyright (C) 2006 - JScience (http://jscience.org/)
  * All rights reserved.
- * 
+ *
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
@@ -10,9 +10,9 @@ package javax.measure.converter;
 
 /**
  * <p> This class represents a converter multiplying numeric values by an
- *     exact scaling factor (represented as the quotient of two 
+ *     exact scaling factor (represented as the quotient of two
  *     <code>long</code> numbers).</p>
- *  
+ *
  * <p> Instances of this class are immutable.</p>
  *
  * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
@@ -31,7 +31,7 @@ public final class RationalConverter extends UnitConverter {
     private final long _divisor;
 
     /**
-     * Creates a rational converter with the specified dividend and 
+     * Creates a rational converter with the specified dividend and
      * divisor.
      *
      * @param dividend the dividend.
@@ -42,7 +42,7 @@ public final class RationalConverter extends UnitConverter {
     public RationalConverter(long dividend, long divisor) {
         if (divisor < 0)
             throw new IllegalArgumentException("Negative divisor");
-        if (dividend == divisor) 
+        if (dividend == divisor)
             throw new IllegalArgumentException("Identity converter not allowed");
         _dividend = dividend;
         _divisor = divisor;
@@ -90,7 +90,7 @@ public final class RationalConverter extends UnitConverter {
             long divisorLong = this._divisor * that._divisor;
             double dividendDouble = ((double)this._dividend) * that._dividend;
             double divisorDouble = ((double)this._divisor) * that._divisor;
-            if ((dividendLong != dividendDouble) || 
+            if ((dividendLong != dividendDouble) ||
                     (divisorLong != divisorDouble)) { // Long overflows.
                 return new MultiplyConverter(dividendDouble / divisorDouble);
             }
@@ -103,6 +103,21 @@ public final class RationalConverter extends UnitConverter {
         }
     }
 
+    @Override
+    public boolean equals(Object cvtr) {
+        if (this == cvtr) {
+            return true;
+        }
+        if (cvtr instanceof RationalConverter) {
+            RationalConverter that = (RationalConverter) cvtr;
+            return ((double) this._dividend) / this._divisor == ((double) that.getDividend()) / that.getDivisor();
+        }
+        if (cvtr instanceof MultiplyConverter) {
+            return ((double) this._dividend) / this._divisor == ((MultiplyConverter) cvtr).getFactor();
+        }
+        return super.equals(cvtr);
+    }
+
     private static UnitConverter valueOf(long dividend, long divisor) {
         return (dividend == 1L) && (divisor == 1L) ? UnitConverter.IDENTITY
                 : new RationalConverter(dividend, divisor);
@@ -112,7 +127,7 @@ public final class RationalConverter extends UnitConverter {
      * Returns the greatest common divisor (Euclid's algorithm).
      *
      * @param  m the first number.
-     * @param  nn the second number.
+     * @param  n the second number.
      * @return the greatest common divisor.
      */
     private static long gcd(long m, long n) {

--- a/src/main/java/javax/measure/converter/UnitConverter.java
+++ b/src/main/java/javax/measure/converter/UnitConverter.java
@@ -2,7 +2,7 @@
  * JScience - Java(TM) Tools and Libraries for the Advancement of Sciences.
  * Copyright (C) 2006 - JScience (http://jscience.org/)
  * All rights reserved.
- * 
+ *
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
@@ -12,16 +12,16 @@ import java.io.Serializable;
 
 /**
  * <p> This class represents a converter of numeric values.</p>
- * 
- * <p> It is not required for sub-classes to be immutable
- *     (e.g. currency converter).</p>
- *     
- * <p> Sub-classes must ensure unicity of the {@link #IDENTITY identity} 
- *     converter. In other words, if the result of an operation is equivalent
- *     to the identity converter, then the unique {@link #IDENTITY} instance 
- *     should be returned.</p>
  *
- * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
+ * <p> It is not required for sub-classes to be immutable
+ * (e.g. currency converter).</p>
+ *
+ * <p> Sub-classes must ensure unicity of the {@link #IDENTITY identity}
+ * converter. In other words, if the result of an operation is equivalent
+ * to the identity converter, then the unique {@link #IDENTITY} instance
+ * should be returned.</p>
+ *
+ * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @version 3.1, April 22, 2006
  */
 public abstract class UnitConverter implements Serializable {
@@ -50,9 +50,11 @@ public abstract class UnitConverter implements Serializable {
     /**
      * Converts a double value.
      *
-     * @param  x the numeric value to convert.
+     * @param x
+     *         the numeric value to convert.
      * @return the converted numeric value.
-     * @throws ConversionException if an error occurs during conversion.
+     * @throws ConversionException
+     *         if an error occurs during conversion.
      */
     public abstract double convert(double x) throws ConversionException;
 
@@ -61,8 +63,8 @@ public abstract class UnitConverter implements Serializable {
      * <code>convert(u + v) == convert(u) + convert(v)</code> and
      * <code>convert(r * u) == r * convert(u)</code>.
      * For linear converters the following property always hold:[code]
-     *     y1 = c1.convert(x1);
-     *     y2 = c2.convert(x2); 
+     * y1 = c1.convert(x1);
+     * y2 = c2.convert(x2);
      * then y1*y2 = c1.concatenate(c2).convert(x1*x2)[/code]
      *
      * @return <code>true</code> if this converter is linear;
@@ -71,17 +73,19 @@ public abstract class UnitConverter implements Serializable {
     public abstract boolean isLinear();
 
     /**
-     * Indicates whether this converter is considered the same as the  
-     * converter specified. To be considered equal this converter 
+     * Indicates whether this converter is considered the same as the
+     * converter specified. To be considered equal this converter
      * concatenated with the one specified must returns the {@link #IDENTITY}.
      *
-     * @param  cvtr the converter with which to compare.
-     * @return <code>true</code> if the specified object is a converter 
+     * @param cvtr
+     *         the converter with which to compare.
+     * @return <code>true</code> if the specified object is a converter
      *         considered equals to this converter;<code>false</code> otherwise.
      */
     public boolean equals(Object cvtr) {
-        if (!(cvtr instanceof UnitConverter)) return false;
-        return this.concatenate(((UnitConverter)cvtr).inverse()) == IDENTITY;        
+        if (this == cvtr) { return true; }
+        if (!(cvtr instanceof UnitConverter)) { return false;}
+        return this.concatenate(((UnitConverter) cvtr).inverse()) == IDENTITY;
     }
 
     /**
@@ -89,22 +93,23 @@ public abstract class UnitConverter implements Serializable {
      * hash codes.
      *
      * @return this converter hash code value.
-     * @see    #equals
+     * @see #equals
      */
     public int hashCode() {
-        return Float.floatToIntBits((float)convert(1.0));
+        return Float.floatToIntBits((float) convert(1.0));
     }
 
     /**
      * Concatenates this converter with another converter. The resulting
      * converter is equivalent to first converting by the specified converter,
      * and then converting by this converter.
-     * 
+     *
      * <p>Note: Implementations must ensure that the {@link #IDENTITY} instance
-     *          is returned if the resulting converter is an identity 
-     *          converter.</p> 
-     * 
-     * @param  converter the other converter.
+     * is returned if the resulting converter is an identity
+     * converter.</p>
+     *
+     * @param converter
+     *         the other converter.
      * @return the concatenation of this converter with the other converter.
      */
     public UnitConverter concatenate(UnitConverter converter) {
@@ -159,8 +164,10 @@ public abstract class UnitConverter implements Serializable {
          * Creates a compound converter resulting from the combined
          * transformation of the specified converters.
          *
-         * @param  first the first converter.
-         * @param  second the second converter.
+         * @param first
+         *         the first converter.
+         * @param second
+         *         the second converter.
          */
         private Compound(UnitConverter first, UnitConverter second) {
             _first = first;

--- a/src/main/java/javax/measure/converter/UnitConverter.java
+++ b/src/main/java/javax/measure/converter/UnitConverter.java
@@ -14,14 +14,14 @@ import java.io.Serializable;
  * <p> This class represents a converter of numeric values.</p>
  *
  * <p> It is not required for sub-classes to be immutable
- * (e.g. currency converter).</p>
+ *     (e.g. currency converter).</p>
  *
  * <p> Sub-classes must ensure unicity of the {@link #IDENTITY identity}
- * converter. In other words, if the result of an operation is equivalent
- * to the identity converter, then the unique {@link #IDENTITY} instance
- * should be returned.</p>
+ *     converter. In other words, if the result of an operation is equivalent
+ *     to the identity converter, then the unique {@link #IDENTITY} instance
+ *     should be returned.</p>
  *
- * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
+ * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @version 3.1, April 22, 2006
  */
 public abstract class UnitConverter implements Serializable {
@@ -50,11 +50,9 @@ public abstract class UnitConverter implements Serializable {
     /**
      * Converts a double value.
      *
-     * @param x
-     *         the numeric value to convert.
+     * @param  x the numeric value to convert.
      * @return the converted numeric value.
-     * @throws ConversionException
-     *         if an error occurs during conversion.
+     * @throws ConversionException if an error occurs during conversion.
      */
     public abstract double convert(double x) throws ConversionException;
 
@@ -63,8 +61,8 @@ public abstract class UnitConverter implements Serializable {
      * <code>convert(u + v) == convert(u) + convert(v)</code> and
      * <code>convert(r * u) == r * convert(u)</code>.
      * For linear converters the following property always hold:[code]
-     * y1 = c1.convert(x1);
-     * y2 = c2.convert(x2);
+     *     y1 = c1.convert(x1);
+     *     y2 = c2.convert(x2);
      * then y1*y2 = c1.concatenate(c2).convert(x1*x2)[/code]
      *
      * @return <code>true</code> if this converter is linear;
@@ -77,15 +75,14 @@ public abstract class UnitConverter implements Serializable {
      * converter specified. To be considered equal this converter
      * concatenated with the one specified must returns the {@link #IDENTITY}.
      *
-     * @param cvtr
-     *         the converter with which to compare.
+     * @param  cvtr the converter with which to compare.
      * @return <code>true</code> if the specified object is a converter
      *         considered equals to this converter;<code>false</code> otherwise.
      */
     public boolean equals(Object cvtr) {
-        if (this == cvtr) { return true; }
-        if (!(cvtr instanceof UnitConverter)) { return false;}
-        return this.concatenate(((UnitConverter) cvtr).inverse()) == IDENTITY;
+        if (this == cvtr) return true;
+        if (!(cvtr instanceof UnitConverter)) return false;
+        return this.concatenate(((UnitConverter)cvtr).inverse()) == IDENTITY;
     }
 
     /**
@@ -93,10 +90,10 @@ public abstract class UnitConverter implements Serializable {
      * hash codes.
      *
      * @return this converter hash code value.
-     * @see #equals
+     * @see    #equals
      */
     public int hashCode() {
-        return Float.floatToIntBits((float) convert(1.0));
+        return Float.floatToIntBits((float)convert(1.0));
     }
 
     /**
@@ -105,11 +102,10 @@ public abstract class UnitConverter implements Serializable {
      * and then converting by this converter.
      *
      * <p>Note: Implementations must ensure that the {@link #IDENTITY} instance
-     * is returned if the resulting converter is an identity
-     * converter.</p>
+     *          is returned if the resulting converter is an identity
+     *          converter.</p>
      *
-     * @param converter
-     *         the other converter.
+     * @param  converter the other converter.
      * @return the concatenation of this converter with the other converter.
      */
     public UnitConverter concatenate(UnitConverter converter) {
@@ -164,10 +160,8 @@ public abstract class UnitConverter implements Serializable {
          * Creates a compound converter resulting from the combined
          * transformation of the specified converters.
          *
-         * @param first
-         *         the first converter.
-         * @param second
-         *         the second converter.
+         * @param  first the first converter.
+         * @param  second the second converter.
          */
         private Compound(UnitConverter first, UnitConverter second) {
             _first = first;

--- a/src/main/java/javax/measure/converter/UnitConverter.java
+++ b/src/main/java/javax/measure/converter/UnitConverter.java
@@ -2,7 +2,7 @@
  * JScience - Java(TM) Tools and Libraries for the Advancement of Sciences.
  * Copyright (C) 2006 - JScience (http://jscience.org/)
  * All rights reserved.
- *
+ * 
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
@@ -12,13 +12,13 @@ import java.io.Serializable;
 
 /**
  * <p> This class represents a converter of numeric values.</p>
- *
+ * 
  * <p> It is not required for sub-classes to be immutable
  *     (e.g. currency converter).</p>
- *
- * <p> Sub-classes must ensure unicity of the {@link #IDENTITY identity}
+ *     
+ * <p> Sub-classes must ensure unicity of the {@link #IDENTITY identity} 
  *     converter. In other words, if the result of an operation is equivalent
- *     to the identity converter, then the unique {@link #IDENTITY} instance
+ *     to the identity converter, then the unique {@link #IDENTITY} instance 
  *     should be returned.</p>
  *
  * @author  <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
@@ -62,7 +62,7 @@ public abstract class UnitConverter implements Serializable {
      * <code>convert(r * u) == r * convert(u)</code>.
      * For linear converters the following property always hold:[code]
      *     y1 = c1.convert(x1);
-     *     y2 = c2.convert(x2);
+     *     y2 = c2.convert(x2); 
      * then y1*y2 = c1.concatenate(c2).convert(x1*x2)[/code]
      *
      * @return <code>true</code> if this converter is linear;
@@ -71,18 +71,18 @@ public abstract class UnitConverter implements Serializable {
     public abstract boolean isLinear();
 
     /**
-     * Indicates whether this converter is considered the same as the
-     * converter specified. To be considered equal this converter
+     * Indicates whether this converter is considered the same as the  
+     * converter specified. To be considered equal this converter 
      * concatenated with the one specified must returns the {@link #IDENTITY}.
      *
      * @param  cvtr the converter with which to compare.
-     * @return <code>true</code> if the specified object is a converter
+     * @return <code>true</code> if the specified object is a converter 
      *         considered equals to this converter;<code>false</code> otherwise.
      */
     public boolean equals(Object cvtr) {
         if (this == cvtr) return true;
         if (!(cvtr instanceof UnitConverter)) return false;
-        return this.concatenate(((UnitConverter)cvtr).inverse()) == IDENTITY;
+        return this.concatenate(((UnitConverter)cvtr).inverse()) == IDENTITY;        
     }
 
     /**
@@ -100,11 +100,11 @@ public abstract class UnitConverter implements Serializable {
      * Concatenates this converter with another converter. The resulting
      * converter is equivalent to first converting by the specified converter,
      * and then converting by this converter.
-     *
+     * 
      * <p>Note: Implementations must ensure that the {@link #IDENTITY} instance
-     *          is returned if the resulting converter is an identity
-     *          converter.</p>
-     *
+     *          is returned if the resulting converter is an identity 
+     *          converter.</p> 
+     * 
      * @param  converter the other converter.
      * @return the concatenation of this converter with the other converter.
      */

--- a/src/test/java/javax/measure/converter/ConverterTest.java
+++ b/src/test/java/javax/measure/converter/ConverterTest.java
@@ -1,0 +1,42 @@
+package javax.measure.converter;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+
+import javax.measure.unit.Unit;
+import javax.measure.unit.UnitFormat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ConverterTest {
+
+    @Test
+    public void equalsTest() throws ParseException {
+        UnitFormat format = UnitFormat.getInstance();
+        {
+            // BaseUnit test
+            Unit<?> a = format.parseProductUnit("m", new ParsePosition(0));
+            Unit<?> b = format.parseProductUnit("m", new ParsePosition(0));
+            Unit<?> c = format.parseProductUnit("km", new ParsePosition(0));
+
+            assertThat(a.getConverterTo(b)).isEqualTo(b.getConverterTo(a));
+            assertThat(a.getConverterTo(c)).isEqualTo(b.getConverterTo(c));
+            assertThat(c.getConverterTo(a)).isEqualTo(c.getConverterTo(b));
+
+            assertThat(a.getConverterTo(b)).isNotEqualTo(a.getConverterTo(c));
+        }
+        {
+            // CompoundUnit test
+            Unit<?> a = format.parseProductUnit("N", new ParsePosition(0));
+            Unit<?> b = format.parseProductUnit("kg*m/s^2", new ParsePosition(0));
+            Unit<?> c = format.parseProductUnit("kN", new ParsePosition(0));
+
+            assertThat(a.getConverterTo(b)).isEqualTo(b.getConverterTo(a));
+            assertThat(a.getConverterTo(c)).isEqualTo(b.getConverterTo(c));
+            assertThat(c.getConverterTo(a)).isEqualTo(c.getConverterTo(b));
+
+            assertThat(a.getConverterTo(b)).isNotEqualTo(a.getConverterTo(c));
+        }
+    }
+}


### PR DESCRIPTION
The fix is two-fold. In UnitConverter.equals and some overrides, check reference equality first. We only generate a single Unit of each type, so this already eliminates an enormous number of UnitConverter creations and covers some of the more arcane converters. In addition, for the most commonly used converter (RationalConverter, but the fix also applies to Add and Multiply converters.), add a path to describe inequality if internal fields don’t match (it can also catch matches, but I’m not sure if any of these will exist given the reference checks).

 

I did notice a bug that certain kinds of converters (Compound) could be mathematically equivalent but not satisfy the existing equals method. I don’t think we run into this anywhere, but that seems mostly by accident and this could hurt some future expansions in the Units area. Filing a CRAB and freezering it.