### PR TITLE
CRAB-27661: Speed up UnitConverter#hashCode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.3</version>
+    <version>5.2.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/converter/AddConverter.java
+++ b/src/main/java/javax/measure/converter/AddConverter.java
@@ -8,7 +8,6 @@
  */
 package javax.measure.converter;
 
-
 /**
  * <p> This class represents a converter adding a constant offset 
  *     (approximated as a <code>double</code>) to numeric values.</p>
@@ -79,7 +78,12 @@ public final class AddConverter extends UnitConverter {
         if (cvtr instanceof AddConverter) {
             return this._offset == ((AddConverter) cvtr).getOffset();
         }
-        return super.equals(cvtr);
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this._offset);
     }
 
     private static UnitConverter valueOf(double offset) {

--- a/src/main/java/javax/measure/converter/LogConverter.java
+++ b/src/main/java/javax/measure/converter/LogConverter.java
@@ -8,6 +8,8 @@
  */
 package javax.measure.converter;
 
+import java.util.Objects;
+
 /**
  * <p> This class represents a logarithmic converter. Such converter 
  *     is typically used to create logarithmic unit. For example:[code]
@@ -78,6 +80,23 @@ public final class LogConverter extends UnitConverter {
         return false;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof LogConverter) {
+            LogConverter that = (LogConverter) o;
+            return that._base == this._base;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this._base);
+    }
+
     /**
      * This inner class represents the inverse of the logarithmic converter
      * (exponentiation converter).
@@ -98,6 +117,24 @@ public final class LogConverter extends UnitConverter {
         @Override
         public boolean isLinear() {
             return false;
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o instanceof Inverse) {
+                Inverse that = (Inverse) o;
+                return that.inverse().equals(this.inverse());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return -this.inverse().hashCode();
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/javax/measure/converter/MultiplyConverter.java
+++ b/src/main/java/javax/measure/converter/MultiplyConverter.java
@@ -94,7 +94,12 @@ public final class MultiplyConverter extends UnitConverter {
             RationalConverter that = (RationalConverter) cvtr;
             return this._factor == ((double) that.getDividend()) / that.getDivisor();
         }
-        return super.equals(cvtr);
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this._factor);
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/javax/measure/converter/RationalConverter.java
+++ b/src/main/java/javax/measure/converter/RationalConverter.java
@@ -115,7 +115,12 @@ public final class RationalConverter extends UnitConverter {
         if (cvtr instanceof MultiplyConverter) {
             return ((double) this._dividend) / this._divisor == ((MultiplyConverter) cvtr).getFactor();
         }
-        return super.equals(cvtr);
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode((double) this._dividend / this._divisor);
     }
 
     private static UnitConverter valueOf(long dividend, long divisor) {

--- a/src/main/java/javax/measure/converter/UnitConverter.java
+++ b/src/main/java/javax/measure/converter/UnitConverter.java
@@ -71,32 +71,6 @@ public abstract class UnitConverter implements Serializable {
     public abstract boolean isLinear();
 
     /**
-     * Indicates whether this converter is considered the same as the  
-     * converter specified. To be considered equal this converter 
-     * concatenated with the one specified must returns the {@link #IDENTITY}.
-     *
-     * @param  cvtr the converter with which to compare.
-     * @return <code>true</code> if the specified object is a converter 
-     *         considered equals to this converter;<code>false</code> otherwise.
-     */
-    public boolean equals(Object cvtr) {
-        if (this == cvtr) return true;
-        if (!(cvtr instanceof UnitConverter)) return false;
-        return this.concatenate(((UnitConverter)cvtr).inverse()) == IDENTITY;        
-    }
-
-    /**
-     * Returns a hash code value for this converter. Equals object have equal
-     * hash codes.
-     *
-     * @return this converter hash code value.
-     * @see    #equals
-     */
-    public int hashCode() {
-        return Float.floatToIntBits((float)convert(1.0));
-    }
-
-    /**
      * Concatenates this converter with another converter. The resulting
      * converter is equivalent to first converting by the specified converter,
      * and then converting by this converter.
@@ -139,6 +113,15 @@ public abstract class UnitConverter implements Serializable {
 
         private static final long serialVersionUID = 1L;
 
+        @Override
+        public boolean equals(Object cvtr) {
+            return cvtr instanceof Identity;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
     }
 
     /**
@@ -181,6 +164,23 @@ public abstract class UnitConverter implements Serializable {
         @Override
         public boolean isLinear() {
             return _first.isLinear() && _second.isLinear();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o instanceof Compound) {
+                Compound compound = (Compound) o;
+                return this._first.equals(compound._first) && this._second.equals(compound._second);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31* this._first.hashCode() + this._second.hashCode();
         }
 
         private static final long serialVersionUID = 1L;

--- a/src/main/java/javax/measure/unit/TransformedUnit.java
+++ b/src/main/java/javax/measure/unit/TransformedUnit.java
@@ -103,7 +103,7 @@ public final class TransformedUnit<Q extends Quantity> extends DerivedUnit<Q> {
 
     // Implements abstract method.
     public int hashCode() {
-        return _parentUnit.hashCode() + _toParentUnit.hashCode();
+        return 31 * _parentUnit.hashCode() + _toParentUnit.hashCode();
     }
 
     // Implements abstract method.


### PR DESCRIPTION
By overriding hashCode in each subclass, rather than doing a conversion.
This also results in stronger hash codes, because previously the hashes
of AddConverter(1) and MultiplyConverter(2) were identical.

This also adds a few equals methods that didn't make it into https://github.com/seeq12/jscience/pull/8

This is a complementary change to a performance improvement I'm doing
in the crab repo, but it's just good practice on its own and mirrors the state
in the last known version of [jscience](https://github.com/javolution/jscience).