### PR TITLE
Fix performance of Unit#pow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.4</version>
+    <version>5.2.5</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/unit/Unit.java
+++ b/src/main/java/javax/measure/unit/Unit.java
@@ -448,7 +448,7 @@ public abstract class Unit<Q extends Quantity> implements Serializable {
      */
     public final Unit<? extends Quantity> pow(int n) {
         if (n > 0) {
-            return this.times(this.pow(n - 1));
+            return ProductUnit.getPowInstance(this, n);
         } else if (n == 0) {
             return ONE;
         } else { // n < 0


### PR DESCRIPTION
The previous algorithm used recursion, which gets more costly as the exponent
increases. ProductUnit#getPowInstance on the other hand always has predictable cost, based
on the number of components the unit has.