### PR TITLE
CRAB-33017: Performance improvements for getConverterTo and getStandardUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.5</version>
+    <version>5.2.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/javax/measure/unit/ProductUnit.java
+++ b/src/main/java/javax/measure/unit/ProductUnit.java
@@ -42,6 +42,17 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
      */
     private int _hashCode;
 
+
+    /**
+     * Holds the standard unit of this unit.
+     */
+    private Unit<? super Q> _standardUnit;
+
+    /**
+     * Holds the standard unit converter of this unit.
+     */
+    private UnitConverter _standardUnitConverter;
+
     /**
      * Default constructor (used solely to create <code>ONE</code> instance).
      */
@@ -333,8 +344,16 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Unit<? super Q> getStandardUnit() {
+        if(_standardUnit == null) {
+            _standardUnit = computeStandardUnit();
+        }
+
+        return _standardUnit;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Unit<? super Q> computeStandardUnit() {
         if (hasOnlyStandardUnit())
             return this;
         Unit systemUnit = ONE;
@@ -349,6 +368,14 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
 
     @Override
     public UnitConverter toStandardUnit() {
+        if (_standardUnitConverter == null) {
+            _standardUnitConverter = computeStandardUnitConverter();
+        }
+
+        return _standardUnitConverter;
+    }
+
+    private UnitConverter computeStandardUnitConverter() {
         if (hasOnlyStandardUnit())
             return UnitConverter.IDENTITY;
         UnitConverter converter = UnitConverter.IDENTITY;

--- a/src/main/java/javax/measure/unit/TransformedUnit.java
+++ b/src/main/java/javax/measure/unit/TransformedUnit.java
@@ -50,6 +50,16 @@ public final class TransformedUnit<Q extends Quantity> extends DerivedUnit<Q> {
     private final UnitConverter _toParentUnit;
 
     /**
+     * Holds the standard unit of this unit.
+     */
+    private Unit<? super Q> _standardUnit;
+
+    /**
+     * Holds the standard unit converter of this unit.
+     */
+    private UnitConverter _standardUnitConverter;
+
+    /**
      * Creates a transformed unit from the specified parent unit.
      *
      * @param parentUnit the untransformed unit from which this unit is 
@@ -108,11 +118,27 @@ public final class TransformedUnit<Q extends Quantity> extends DerivedUnit<Q> {
 
     // Implements abstract method.
     public Unit<? super Q> getStandardUnit() {
+        if(_standardUnit == null) {
+            _standardUnit = computeStandardUnit();
+        }
+
+        return _standardUnit;
+    }
+
+    private Unit<? super Q> computeStandardUnit() {
         return _parentUnit.getStandardUnit();
     }
 
     // Implements abstract method.
     public UnitConverter toStandardUnit() {
+        if (_standardUnitConverter == null) {
+            _standardUnitConverter = computeStandardUnitConverter();
+        }
+
+        return _standardUnitConverter;
+    }
+
+    private UnitConverter computeStandardUnitConverter() {
         return _parentUnit.toStandardUnit().concatenate(_toParentUnit);
     }
 

--- a/src/test/java/javax/measure/converter/ConverterTest.java
+++ b/src/test/java/javax/measure/converter/ConverterTest.java
@@ -2,6 +2,9 @@ package javax.measure.converter;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.measure.unit.Unit;
 import javax.measure.unit.UnitFormat;
@@ -38,5 +41,62 @@ public class ConverterTest {
 
             assertThat(a.getConverterTo(b)).isNotEqualTo(a.getConverterTo(c));
         }
+    }
+
+    // @Test
+    // Execute this manually to test the concurrency of the cache converters.
+    // Set CONVERTER_CACHE_SIZE_LIMIT to 3 (a value lower than data.length to force many cache clear actions)
+    public void multiThreadTest() throws InterruptedException {
+        final int THREAD_COUNT = 1_000;
+        final int DATA_ITERATIONS = 10_000;
+        final AtomicInteger errorCount = new AtomicInteger(0);
+        final UnitFormat format = UnitFormat.getUCUMInstance();
+        Object[][] data = {
+                {2.0, "m", 200.0, "cm"}, {2.0, "m", 2000.0, "mm"}, {2.0, "m", 0.002, "km"}, {2.0, "m", 20.0, "dm"},
+                {2.0, "cm", 0.02, "m"}, {2.0, "cm", 20.0, "mm"}, {2.0, "cm", 0.00002, "km"}, {2.0, "cm", 0.2, "dm"},
+                {2000.0, "mm", 2.0, "m"},
+                {0.002, "km", 2.0, "m"},
+                {20.0, "dm", 2.0, "m"},
+                {1.0, "mm^2", 0.01, "cm^2"},
+                {0.01, "cm^2", 0.000001, "m^2"},
+                {0.0001, "m^2", 0.0000000001, "km^2"},
+                {1_000_123.0, "T·g·s/(h·kg)", 277.81194444444446, "T·g/kg"},
+                {1.0, "g/mL", 1000.0, "kg/m^3"}, {1.0, "g/mL", 62.42796057614461, "lb/ft^3"},
+                {1.0, "kPa", 0.001, "MPa"},
+                {1.0, "L/s", 60.0, "L/min"},
+                {60.0, "L/min", 3600.0, "L/h"}
+        };
+
+
+
+        List<Thread> threads = new ArrayList<>(THREAD_COUNT);
+        for(int i = 0; i < THREAD_COUNT; i++) {
+            threads.add(new Thread(() -> {
+                for(int j = 0; j < DATA_ITERATIONS; j++){
+                    for (Object[] datum : data) {
+                        try {
+                            Unit<?> fromUnit = format.parseProductUnit((String) datum[1], new ParsePosition(0));
+                            Unit<?> toUnit = format.parseProductUnit((String) datum[3], new ParsePosition(0));
+                            double inputValue = (double) datum[0];
+                            double outputValue = (double) datum[2];
+                            double output = fromUnit.getConverterTo(toUnit).convert(inputValue);
+                            if(output != outputValue) {
+                                System.out.println("ERROR: Expected " + outputValue + " but got " + output);
+                                errorCount.incrementAndGet();
+                            }
+                        } catch (ParseException e) {
+                            errorCount.incrementAndGet();
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }}));
+        }
+
+        threads.forEach(Thread::start);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertThat(errorCount.get()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
This PR introduces some performance improvements by calculating standartUnit and standardUnitConverter only once. It also adds a cache for unit converters. The changes were done on the units where these computations are expensive.
Initially, the problems were detected while profiling Seeq
Before:
![image](https://user-images.githubusercontent.com/40291980/184493904-110a8acb-f0cd-4ce0-a9e2-e6921c490308.png)
After: - getConverterTo is not in top anymore. getStandardUnit is not present at all in the list
<img width="796" alt="image" src="https://user-images.githubusercontent.com/40291980/184493925-2d86f762-31cd-4c0e-a89f-45cffe379112.png">


Measurements with ScalarMathBenchmark:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/40291980/184494007-e7ccd34e-b52d-4ca9-8cd3-b414062c8f7b.png">

Measurements on the workbook with complex formulas:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/40291980/184494123-7f5dfb99-7897-4b8b-ad8c-bb55af9f9942.png">



