### PR TITLE
Cache ProductUnits and their standardUnit/standardUnitConverter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.5</version>
+    <version>5.2.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.javolution</groupId>
             <artifactId>javolution</artifactId>
             <version>5.3.1</version>

--- a/src/main/java/javax/measure/unit/ProductUnit.java
+++ b/src/main/java/javax/measure/unit/ProductUnit.java
@@ -2,22 +2,26 @@
  * JScience - Java(TM) Tools and Libraries for the Advancement of Sciences.
  * Copyright (C) 2006 - JScience (http://jscience.org/)
  * All rights reserved.
- * 
+ *
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
 package javax.measure.unit;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 import javax.measure.converter.ConversionException;
 import javax.measure.converter.UnitConverter;
 import javax.measure.quantity.Quantity;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
 /**
  * <p> This class represents units formed by the product of rational powers of
  *     existing units.</p>
- *     
+ *
  * <p> This class maintains the canonical form of this product (simplest
  *     form after factorization). For example:
  *     <code>METER.pow(2).divide(METER)</code> returns
@@ -64,11 +68,11 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
      * Copy constructor (allows for parameterization of product units).
      *
      * @param productUnit the product unit source.
-     * @throws ClassCastException if the specified unit is not 
+     * @throws ClassCastException if the specified unit is not
      *         a product unit.
      */
     public ProductUnit(Unit<?> productUnit) {
-        _elements = ((ProductUnit<?>)productUnit)._elements;        
+        _elements = ((ProductUnit<?>)productUnit)._elements;
     }
 
     /**
@@ -80,6 +84,12 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
         _elements = elements;
     }
 
+    private static final LoadingCache<ProductUnitKey, Unit<? extends Quantity>> INSTANCE_CACHE =
+            Caffeine.newBuilder()
+                    .maximumSize(4096)
+                    .build(key -> doGetInstance(key._leftElems, key._rightElems));
+
+
     /**
      * Returns the unit defined from the product of the specifed elements.
      *
@@ -87,10 +97,12 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
      * @param  rightElems right multiplicand elements.
      * @return the corresponding unit.
      */
-    @SuppressWarnings("unchecked")
-    private static Unit<? extends Quantity> getInstance(Element[] leftElems,
-            Element[] rightElems) {
+    private static Unit<? extends Quantity> getInstance(Element[] leftElems, Element[] rightElems) {
+        return INSTANCE_CACHE.get(new ProductUnitKey(leftElems, rightElems));
+    }
 
+    @SuppressWarnings("unchecked")
+    private static Unit<? extends Quantity> doGetInstance(Element[] leftElems, Element[] rightElems) {
         // Merges left elements with right elements.
         Element[] result = new Element[leftElems.length + rightElems.length];
         int resultIndex = 0;
@@ -291,12 +303,12 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
     }
 
     /**
-     * Indicates if this product unit is considered equals to the specified 
+     * Indicates if this product unit is considered equals to the specified
      * object.
      *
      * @param  that the object to compare for equality.
      * @return <code>true</code> if <code>this</code> and <code>that</code>
-     *         are considered equals; <code>false</code>otherwise. 
+     *         are considered equals; <code>false</code>otherwise.
      */
     public boolean equals(Object that) {
         if (this == that)
@@ -432,7 +444,7 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
     /**
      * Inner product element represents a rational power of a single unit.
      */
-    private final static class Element implements Serializable {
+    private static final class Element implements Serializable {
 
         /**
          * Holds the single unit.
@@ -448,6 +460,7 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
          * Holds the root exponent.
          */
         private final int _root;
+        private int _hashCode;
 
         /**
          * Structural constructor.
@@ -492,6 +505,54 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
         }
 
         private static final long serialVersionUID = 1L;
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Element) {
+                Element other = (Element) obj;
+                return _hashCode == other._hashCode
+                        && _unit.equals(other._unit)
+                        && _pow == other._pow
+                        && _root == other._root;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            if (_hashCode == 0) {
+                _hashCode = 31 * (31 * _unit.hashCode() + Integer.hashCode(_pow)) + Integer.hashCode(_root);
+            }
+            return _hashCode;
+        }
+    }
+
+    private static final class ProductUnitKey {
+        private final Element[] _leftElems;
+        private final Element[] _rightElems;
+        private final int _hashCode;
+
+        private ProductUnitKey(Element[] leftElems, Element[] rightElems) {
+            this._leftElems = leftElems;
+            this._rightElems = rightElems;
+            this._hashCode = 31 * Arrays.hashCode(leftElems) + Arrays.hashCode(rightElems);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof ProductUnitKey) {
+                ProductUnitKey other = (ProductUnitKey) obj;
+                return _hashCode == other._hashCode
+                        && Arrays.equals(_leftElems, other._leftElems)
+                        && Arrays.equals(_rightElems, other._rightElems);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return _hashCode;
+        }
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/javax/measure/unit/ProductUnit.java
+++ b/src/main/java/javax/measure/unit/ProductUnit.java
@@ -42,6 +42,17 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
      */
     private int _hashCode;
 
+
+    /**
+     * Holds the standard unit of this unit.
+     */
+    private Unit<? super Q> _standardUnit;
+
+    /**
+     * Holds the standard unit converter of this unit.
+     */
+    private UnitConverter _standardUnitConverter;
+
     /**
      * Default constructor (used solely to create <code>ONE</code> instance).
      */
@@ -333,8 +344,16 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Unit<? super Q> getStandardUnit() {
+        if(_standardUnit == null) {
+            _standardUnit = computeStandardUnit();
+        }
+
+        return _standardUnit;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Unit<? super Q> computeStandardUnit() {
         if (hasOnlyStandardUnit())
             return this;
         Unit systemUnit = ONE;
@@ -349,6 +368,14 @@ public final class ProductUnit<Q extends Quantity> extends DerivedUnit<Q> {
 
     @Override
     public UnitConverter toStandardUnit() {
+        if (_standardUnitConverter == null) {
+            _standardUnitConverter = computeStandardUnitConverter();
+        }
+
+        return _standardUnitConverter;
+    }
+
+    private UnitConverter computeStandardUnitConverter() {
         if (hasOnlyStandardUnit())
             return UnitConverter.IDENTITY;
         UnitConverter converter = UnitConverter.IDENTITY;

--- a/src/main/java/javax/measure/unit/TransformedUnit.java
+++ b/src/main/java/javax/measure/unit/TransformedUnit.java
@@ -50,6 +50,16 @@ public final class TransformedUnit<Q extends Quantity> extends DerivedUnit<Q> {
     private final UnitConverter _toParentUnit;
 
     /**
+     * Holds the standard unit of this unit.
+     */
+    private Unit<? super Q> _standardUnit;
+
+    /**
+     * Holds the standard unit converter of this unit.
+     */
+    private UnitConverter _standardUnitConverter;
+
+    /**
      * Creates a transformed unit from the specified parent unit.
      *
      * @param parentUnit the untransformed unit from which this unit is 
@@ -108,11 +118,27 @@ public final class TransformedUnit<Q extends Quantity> extends DerivedUnit<Q> {
 
     // Implements abstract method.
     public Unit<? super Q> getStandardUnit() {
+        if(_standardUnit == null) {
+            _standardUnit = computeStandardUnit();
+        }
+
+        return _standardUnit;
+    }
+
+    private Unit<? super Q> computeStandardUnit() {
         return _parentUnit.getStandardUnit();
     }
 
     // Implements abstract method.
     public UnitConverter toStandardUnit() {
+        if (_standardUnitConverter == null) {
+            _standardUnitConverter = computeStandardUnitConverter();
+        }
+
+        return _standardUnitConverter;
+    }
+
+    private UnitConverter computeStandardUnitConverter() {
         return _parentUnit.toStandardUnit().concatenate(_toParentUnit);
     }
 

--- a/src/test/java/javax/measure/converter/ConverterTest.java
+++ b/src/test/java/javax/measure/converter/ConverterTest.java
@@ -2,6 +2,9 @@ package javax.measure.converter;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.measure.unit.Unit;
 import javax.measure.unit.UnitFormat;
@@ -38,5 +41,62 @@ public class ConverterTest {
 
             assertThat(a.getConverterTo(b)).isNotEqualTo(a.getConverterTo(c));
         }
+    }
+
+    // @Test
+    // Execute this manually to test the concurrency of the cache converters.
+    // Set CONVERTER_CACHE_SIZE_LIMIT to 3 (a value lower than data.length to force many cache clear actions)
+    public void multiThreadTest() throws InterruptedException {
+        final int THREAD_COUNT = 1_000;
+        final int DATA_ITERATIONS = 10_000;
+        final AtomicInteger errorCount = new AtomicInteger(0);
+        final UnitFormat format = UnitFormat.getUCUMInstance();
+        Object[][] data = {
+                {2.0, "m", 200.0, "cm"}, {2.0, "m", 2000.0, "mm"}, {2.0, "m", 0.002, "km"}, {2.0, "m", 20.0, "dm"},
+                {2.0, "cm", 0.02, "m"}, {2.0, "cm", 20.0, "mm"}, {2.0, "cm", 0.00002, "km"}, {2.0, "cm", 0.2, "dm"},
+                {2000.0, "mm", 2.0, "m"},
+                {0.002, "km", 2.0, "m"},
+                {20.0, "dm", 2.0, "m"},
+                {1.0, "mm^2", 0.01, "cm^2"},
+                {0.01, "cm^2", 0.000001, "m^2"},
+                {0.0001, "m^2", 0.0000000001, "km^2"},
+                {1_000_123.0, "T·g·s/(h·kg)", 277.81194444444446, "T·g/kg"},
+                {1.0, "g/mL", 1000.0, "kg/m^3"}, {1.0, "g/mL", 62.42796057614461, "lb/ft^3"},
+                {1.0, "kPa", 0.001, "MPa"},
+                {1.0, "L/s", 60.0, "L/min"},
+                {60.0, "L/min", 3600.0, "L/h"}
+        };
+
+
+
+        List<Thread> threads = new ArrayList<>(THREAD_COUNT);
+        for(int i = 0; i < THREAD_COUNT; i++) {
+            threads.add(new Thread(() -> {
+                for(int j = 0; j < DATA_ITERATIONS; j++){
+                    for (Object[] datum : data) {
+                        try {
+                            Unit<?> fromUnit = format.parseProductUnit((String) datum[1], new ParsePosition(0));
+                            Unit<?> toUnit = format.parseProductUnit((String) datum[3], new ParsePosition(0));
+                            double inputValue = (double) datum[0];
+                            double outputValue = (double) datum[2];
+                            double output = fromUnit.getConverterTo(toUnit).convert(inputValue);
+                            if(output != outputValue) {
+                                System.out.println("ERROR: Expected " + outputValue + " but got " + output);
+                                errorCount.incrementAndGet();
+                            }
+                        } catch (ParseException e) {
+                            errorCount.incrementAndGet();
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }}));
+        }
+
+        threads.forEach(Thread::start);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertThat(errorCount.get()).isEqualTo(0);
     }
 }

--- a/src/test/java/javax/measure/converter/ConverterTest.java
+++ b/src/test/java/javax/measure/converter/ConverterTest.java
@@ -2,9 +2,6 @@ package javax.measure.converter;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.measure.unit.Unit;
 import javax.measure.unit.UnitFormat;
@@ -41,62 +38,5 @@ public class ConverterTest {
 
             assertThat(a.getConverterTo(b)).isNotEqualTo(a.getConverterTo(c));
         }
-    }
-
-    // @Test
-    // Execute this manually to test the concurrency of the cache converters.
-    // Set CONVERTER_CACHE_SIZE_LIMIT to 3 (a value lower than data.length to force many cache clear actions)
-    public void multiThreadTest() throws InterruptedException {
-        final int THREAD_COUNT = 1_000;
-        final int DATA_ITERATIONS = 10_000;
-        final AtomicInteger errorCount = new AtomicInteger(0);
-        final UnitFormat format = UnitFormat.getUCUMInstance();
-        Object[][] data = {
-                {2.0, "m", 200.0, "cm"}, {2.0, "m", 2000.0, "mm"}, {2.0, "m", 0.002, "km"}, {2.0, "m", 20.0, "dm"},
-                {2.0, "cm", 0.02, "m"}, {2.0, "cm", 20.0, "mm"}, {2.0, "cm", 0.00002, "km"}, {2.0, "cm", 0.2, "dm"},
-                {2000.0, "mm", 2.0, "m"},
-                {0.002, "km", 2.0, "m"},
-                {20.0, "dm", 2.0, "m"},
-                {1.0, "mm^2", 0.01, "cm^2"},
-                {0.01, "cm^2", 0.000001, "m^2"},
-                {0.0001, "m^2", 0.0000000001, "km^2"},
-                {1_000_123.0, "T·g·s/(h·kg)", 277.81194444444446, "T·g/kg"},
-                {1.0, "g/mL", 1000.0, "kg/m^3"}, {1.0, "g/mL", 62.42796057614461, "lb/ft^3"},
-                {1.0, "kPa", 0.001, "MPa"},
-                {1.0, "L/s", 60.0, "L/min"},
-                {60.0, "L/min", 3600.0, "L/h"}
-        };
-
-
-
-        List<Thread> threads = new ArrayList<>(THREAD_COUNT);
-        for(int i = 0; i < THREAD_COUNT; i++) {
-            threads.add(new Thread(() -> {
-                for(int j = 0; j < DATA_ITERATIONS; j++){
-                    for (Object[] datum : data) {
-                        try {
-                            Unit<?> fromUnit = format.parseProductUnit((String) datum[1], new ParsePosition(0));
-                            Unit<?> toUnit = format.parseProductUnit((String) datum[3], new ParsePosition(0));
-                            double inputValue = (double) datum[0];
-                            double outputValue = (double) datum[2];
-                            double output = fromUnit.getConverterTo(toUnit).convert(inputValue);
-                            if(output != outputValue) {
-                                System.out.println("ERROR: Expected " + outputValue + " but got " + output);
-                                errorCount.incrementAndGet();
-                            }
-                        } catch (ParseException e) {
-                            errorCount.incrementAndGet();
-                            throw new RuntimeException(e);
-                        }
-                    }
-                }}));
-        }
-
-        threads.forEach(Thread::start);
-        for (Thread thread : threads) {
-            thread.join();
-        }
-
-        assertThat(errorCount.get()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
This supersedes https://github.com/seeq12/jscience/pull/12. Instead of caching `getConverter`, we now cache `ProductUnit#getInstance`. Once the instance is cached, its `standardUnit` and `standardUnitConverter` are cached too, resulting in fast `getConverter` calls. On top of that, caching `getInstance` is faster than executing it in many cases. It also helps with `ProductUnit.equals` comparisons, reducing them to a reference equality check in the positive case.

I tried many other alternatives:

- Caffeine with only 32 entries. This is too small, as we need to fit all the standard units in `SI.java` and `NonSI.java`. The cache goes into size control immediately, slowing it down.
- [An unbounded ConcurrentHashMap](https://github.com/seeq12/jscience/tree/oehme/converter-cache-unbounded). This is slightly faster, but of course has no protection against degenerate use cases
- [A ThreadLocal](https://github.com/seeq12/jscience/tree/oehme/converter-cache-local) that needs active participation by the client application. This was not much faster than Caffeine, but much more complex and easy to get wrong. Not worth it.

Profiling results with 140million samples from worksheet 2610:
![image](https://user-images.githubusercontent.com/1191797/185615531-51cae7fd-de8a-4db0-b03a-0a636bb7986c.png)
