### PR TITLE
Downgrade Caffeine and bump JScience version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.seeq.jscience</groupId>
     <artifactId>jscience</artifactId>
     <packaging>jar</packaging>
-    <version>5.2.6</version>
+    <version>5.2.7</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>3.1.1</version>
+            <version>2.8.4</version>
         </dependency>
         <dependency>
             <groupId>org.javolution</groupId>


### PR DESCRIPTION
Caffeine 3.x requires Java 11, but the changes that introduced Caffeine as a dependency work with Caffeine 2.8.4.